### PR TITLE
Disable arm64 docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,11 @@ jobs:
   docker:
     name: Docker actions
     uses: RMI-PACTA/actions/.github/workflows/docker.yml@main
+    with:
+      build-platform:
+        [
+          "linux/amd64"
+        ]
 
   test:
     name: Test


### PR DESCRIPTION
Disable arm64 docker builds (to run natively on apple silicon, rather than through rosetta) since the build process is timing out, and causing build failures on `main` (the only branch we build arm64 for)