### PR TITLE
Update issues-gh-to-ado.yml

### DIFF
--- a/.github/workflows/issues-gh-to-ado.yml
+++ b/.github/workflows/issues-gh-to-ado.yml
@@ -1,32 +1,26 @@
+---
+# This example file will enable actions that trigger on created or modified GitHub issues. 
+#
+# Note the @main in `uses:` on the last line. This will call the latest version of the workflow from the `main` branch in the RMI-PACTA/actions repo.
+# You can also specify a tag from that repo, or a commit SHA to pin action versions.
 on:
-  workflow_call:
-    inputs:
-      ado_area_path:
-        description: "ADO area path where ADO tickets are created."
-        required: true
-        default: "2DegreesInvesting\\GitHub Issues"
-        type: string
-    secrets:
-      ADO_TOKEN:
-        description: "ADO personal access token"
-        required: true
-name: Sync GitHub Issues to Azure DevOps 
+  issues:
+    types:
+      [opened, edited, deleted, closed, reopened, labeled, unlabeled, assigned]
+    issue_comment:
+      types: [created, edited, deleted]
+
+name: GH issues
+
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
-  alert:
-    if: ${{ (!github.event.issue.pull_request) && (github.event.label.name == 'ADO' )}}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: danhellem/github-actions-issue-to-work-item@v2.3
-        id: gh_to_ado
-        env:
-          ado_token: "${{ secrets.ADO_TOKEN }}" 
-          github_token: "${{ secrets.GITHUB_TOKEN }}"
-          ado_organization: "RMI-PACTA"
-          ado_project: "2DegreesInvesting"
-          ado_area_path: "${{ inputs.ado_area_path }}"
-          ado_wit: "Product Backlog Item"
-          ado_new_state: "New"
-          ado_active_state: "Committed"
-          ado_close_state: "Done" 
-          log_level: 100
+  issues:
+    name: Run issues workflows
+    uses: RMI-PACTA/actions/.github/workflows/issues.yml@main
+    with:
+      ado_area_path: "2DegreesInvesting\\GitHub Issues"
+    secrets:
+      ADO_TOKEN: ${{ secrets.ADO_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
Call reusable workflow from RMI-PACTA/actions, rather that duplicating here.