### PR TITLE
Use new RMI blob copy action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,12 +167,12 @@ jobs:
           --mount type=bind,readonly,source=${WORKSPACE}/${BENCHMARKS_DIR},target=/mnt/benchmarks_dir \
           --mount type=bind,readonly,source=${WORKSPACE}/${PACTA_DATA_DIR},target=/mnt/pacta-data \
           --mount type=bind,readonly,source=${WORKSPACE}/${PORTFOLIO_DIR},target=/mnt/portfolios \
-          --mount type=bind,readonly,source=${WORKSPACE}/${REAL_ESTATE_DIR},target=/mnt/real_estate_dir \
-          --mount type=bind,readonly,source=${WORKSPACE}/${SCORE_CARD_DIR},target=/mnt/score_card_dir \
-          --mount type=bind,readonly,source=${WORKSPACE}/${SURVEY_DIR},target=/mnt/survey_dir \
-          --mount type=bind,source=${WORKSPACE}/${ANALYSIS_OUTPUT_DIR},target=/mnt/analysis_output_dir \
-          --mount type=bind,source=${WORKSPACE}/${REPORT_OUTPUT_DIR},target=/mnt/report_output_dir \
-          --mount type=bind,source=${WORKSPACE}/${SUMMARY_OUTPUT_DIR},target=/mnt/summary_output_dir \
+          --mount type=bind,readonly,source=${REAL_ESTATE_DIR},target=/mnt/real_estate_dir \
+          --mount type=bind,readonly,source=${SCORE_CARD_DIR},target=/mnt/score_card_dir \
+          --mount type=bind,readonly,source=${SURVEY_DIR},target=/mnt/survey_dir \
+          --mount type=bind,source=${ANALYSIS_OUTPUT_DIR},target=/mnt/analysis_output_dir \
+          --mount type=bind,source=${REPORT_OUTPUT_DIR},target=/mnt/report_output_dir \
+          --mount type=bind,source=${SUMMARY_OUTPUT_DIR},target=/mnt/summary_output_dir \
           $FULL_IMAGE_NAME \
           "$PARAMETERS"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,7 +105,7 @@ jobs:
         env:
           TEST_DIR: ${{ steps.prepare.outputs.test-dir }}
         run: |
-          ls -laR "TEST_DIR"
+          ls -laR "$TEST_DIR"
 
       # https://github.com/Azure/login?tab=readme-ov-file#login-with-openid-connect-oidc-recommended
       - name: Azure Login

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,6 +88,12 @@ jobs:
           echo "real-estate-dir=$REAL_ESTATE_DIR"
           echo "real-estate-dir=$REAL_ESTATE_DIR" >> "$GITHUB_OUTPUT"
 
+          SCORE_CARD_DIR="$TEST_DIR/score_card_dir"
+          mkdir -p "$SCORE_CARD_DIR"
+          chmod -R 777 "$SCORE_CARD_DIR"
+          echo "score-card-dir=$SCORE_CARD_DIR"
+          echo "score-card-dir=$SCORE_CARD_DIR" >> "$GITHUB_OUTPUT"
+
           SURVEY_DIR="$TEST_DIR/survey_dir"
           mkdir -p "$SURVEY_DIR"
           chmod -R 777 "$SURVEY_DIR"
@@ -154,6 +160,7 @@ jobs:
           PORTFOLIO_DIR: tests/portfolios
           REAL_ESTATE_DIR: ${{ steps.prepare.outputs.real-estate-dir }}
           REPORT_OUTPUT_DIR: ${{ steps.prepare.outputs.report-output-dir }}
+          SCORE_CARD_DIR: ${{ steps.prepare.outputs.score-card-dir }}
           SUMMARY_OUTPUT_DIR: ${{ steps.prepare.outputs.summary-output-dir }}
           SURVEY_DIR: ${{ steps.prepare.outputs.survey-dir }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,13 +106,6 @@ jobs:
           echo "analysis-output-dir=$ANALYSIS_OUTPUT_DIR"
           echo "analysis-output-dir=$ANALYSIS_OUTPUT_DIR" >> "$GITHUB_OUTPUT"
 
-      - name: Show TEST_DIR
-        id: ls-test-dir
-        env:
-          TEST_DIR: ${{ steps.prepare.outputs.test-dir }}
-        run: |
-          ls -laR "$TEST_DIR"
-
       # https://github.com/Azure/login?tab=readme-ov-file#login-with-openid-connect-oidc-recommended
       - name: Azure Login
         uses: azure/login@v2
@@ -148,6 +141,13 @@ jobs:
               --destination "benchmarks_dir/" \
               --recursive \
               --exclude-pattern "*.sqlite"
+
+      - name: Show TEST_DIR
+        id: ls-test-dir
+        env:
+          TEST_DIR: ${{ steps.prepare.outputs.test-dir }}
+        run: |
+          ls -laR "$TEST_DIR"
 
       - name: Run Docker Image
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -222,33 +222,6 @@ jobs:
           destination: ${{ inputs.reports-url }}
           overwrite: false
 
-      # https://github.com/marketplace/actions/azure-cli-action#workflow-to-execute-an-azure-cli-script-of-a-specific-cli-version
-      - name: Upload results to blob store
-        id: upload
-        uses: azure/CLI@v2
-        env:
-          CONFIG_NAME: ${{ inputs.config-name }}
-          GITHUB_REF_NAME: ${{ github.ref_name}}
-          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
-          GITHUB_RUN_NUMBER: ${{ github.run_number }}
-          REPORT_OUTPUT_DIR: report_output_dir
-          SUMMARY_OUTPUT_DIR: summary_output_dir
-          RESULTS_URL: ${{ inputs.results-url }}
-        with:
-          inlineScript: |
-            unique_directory="$RESULTS_URL/$GITHUB_REF_NAME/$GITHUB_RUN_NUMBER/$GITHUB_RUN_ATTEMPT/$CONFIG_NAME"
-            az storage copy \
-              --source "$REPORT_OUTPUT_DIR"/* \
-              --destination "$unique_directory" \
-              --recursive
-            echo "report-url=${unique_directory}/report/index.html" >> "$GITHUB_OUTPUT"
-
-            az storage copy \
-              --source "$SUMMARY_OUTPUT_DIR"/* \
-              --destination "$unique_directory" \
-              --recursive
-            echo "summary-url=${unique_directory}/executive_summary/$summary_files" >> "$GITHUB_OUTPUT"
-
       - name: Export Outputs
         id: export-outputs
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,6 +100,13 @@ jobs:
           echo "analysis-output-dir=$ANALYSIS_OUTPUT_DIR"
           echo "analysis-output-dir=$ANALYSIS_OUTPUT_DIR" >> "$GITHUB_OUTPUT"
 
+      - name: Show TEST_DIR
+        id: ls-test-dir
+        env:
+          TEST_DIR: ${{ steps.prepare.outputs.test-dir }}
+        run: |
+          ls -laR "TEST_DIR"
+
       # https://github.com/Azure/login?tab=readme-ov-file#login-with-openid-connect-oidc-recommended
       - name: Azure Login
         uses: azure/login@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,12 @@ on:
       results-url:
         description: azure blob store path for results
         required: false
-        default: "https://pactadatadev.blob.core.windows.net/ghactions-workflow-pacta-report-results"
+        default: "https://pactadatadev.blob.core.windows.net/ghactions-workflow-pacta-webapp-results"
+        type: string
+      reports-url:
+        description: azure blob store path for results
+        required: false
+        default: "https://pactadatadev.blob.core.windows.net/ghactions-workflow-pacta-webapp-results-reports"
         type: string
 
 jobs:
@@ -31,6 +36,10 @@ jobs:
         id: prepare
         env:
           CONFIG_NAME: ${{ inputs.config-name }}
+          GITHUB_REF_NAME: ${{ github.ref_name}}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+          WORKSPACE: ${{ github.workspace }}
         run: |
           config_file="tests/config/$CONFIG_NAME.json"
           echo "config_file: $config_file"
@@ -55,6 +64,41 @@ jobs:
           PARAMETERS="$(jq -rc '.parameters | select( . != null )' $config_file)"
           echo "parameters=$PARAMETERS"
           echo "parameters=$PARAMETERS" >> "$GITHUB_OUTPUT"
+
+          TEST_DIR="$WORKSPACE/$GITHUB_REF_NAME/$GITHUB_RUN_NUMBER/$GITHUB_RUN_ATTEMPT/$CONFIG_NAME"
+          mkdir -p $TEST_DIR
+          echo "test-dir=$TEST_DIR"
+          echo "test-dir=$TEST_DIR" >> "$GITHUB_OUTPUT"
+
+          REPORT_OUTPUT_DIR="$TEST_DIR/report_output_dir"
+          mkdir -p "$REPORT_OUTPUT_DIR"
+          chmod -R 777 "$REPORT_OUTPUT_DIR"
+          echo "report-output-dir=$REPORT_OUTPUT_DIR"
+          echo "report-output-dir=$REPORT_OUTPUT_DIR" >> "$GITHUB_OUTPUT"
+
+          SUMMARY_OUTPUT_DIR="$TEST_DIR/summary_output_dir"
+          mkdir -p "$SUMMARY_OUTPUT_DIR"
+          chmod -R 777 "$SUMMARY_OUTPUT_DIR"
+          echo "summary-output-dir=$SUMMARY_OUTPUT_DIR"
+          echo "summary-output-dir=$SUMMARY_OUTPUT_DIR" >> "$GITHUB_OUTPUT"
+
+          REAL_ESTATE_DIR="$TEST_DIR/real_estate_dir"
+          mkdir -p "$REAL_ESTATE_DIR"
+          chmod -R 777 "$REAL_ESTATE_DIR"
+          echo "real-estate-dir=$REAL_ESTATE_DIR"
+          echo "real-estate-dir=$REAL_ESTATE_DIR" >> "$GITHUB_OUTPUT"
+
+          SURVEY_DIR="$TEST_DIR/survey_dir"
+          mkdir -p "$SURVEY_DIR"
+          chmod -R 777 "$SURVEY_DIR"
+          echo "survey-dir=$SURVEY_DIR"
+          echo "survey-dir=$SURVEY_DIR" >> "$GITHUB_OUTPUT"
+
+          ANALYSIS_OUTPUT_DIR="$TEST_DIR/analysis_output_dir"
+          mkdir -p "$ANALYSIS_OUTPUT_DIR"
+          chmod -R 777 "$ANALYSIS_OUTPUT_DIR"
+          echo "analysis-output-dir=$ANALYSIS_OUTPUT_DIR"
+          echo "analysis-output-dir=$ANALYSIS_OUTPUT_DIR" >> "$GITHUB_OUTPUT"
 
       # https://github.com/Azure/login?tab=readme-ov-file#login-with-openid-connect-oidc-recommended
       - name: Azure Login
@@ -97,25 +141,15 @@ jobs:
           FULL_IMAGE_NAME: ${{ inputs.full-image-name }}
           WORKSPACE: ${{ github.workspace }}
           PARAMETERS: ${{ steps.prepare.outputs.parameters }}
-          ANALYSIS_OUTPUT_DIR: analysis_output_dir
+          ANALYSIS_OUTPUT_DIR: ${{ steps.prepare.outputs.analysis-output-dir }}
           BENCHMARKS_DIR: benchmarks_dir
           PACTA_DATA_DIR: pacta-data
           PORTFOLIO_DIR: tests/portfolios
-          REAL_ESTATE_DIR: real_estate_dir
-          REPORT_OUTPUT_DIR: report_output_dir
-          SUMMARY_OUTPUT_DIR: summary_output_dir
-          SURVEY_DIR: survey_dir
+          REAL_ESTATE_DIR: ${{ steps.prepare.outputs.real-estate-dir }}
+          REPORT_OUTPUT_DIR: ${{ steps.prepare.outputs.report-output-dir }}
+          SUMMARY_OUTPUT_DIR: ${{ steps.prepare.outputs.summary-output-dir }}
+          SURVEY_DIR: ${{ steps.prepare.outputs.survey-dir }}
         run: |
-          mkdir -p "$REPORT_OUTPUT_DIR"
-          chmod -R 777 "$REPORT_OUTPUT_DIR"
-          mkdir -p "$SUMMARY_OUTPUT_DIR"
-          chmod -R 777 "$SUMMARY_OUTPUT_DIR"
-          mkdir -p "$REAL_ESTATE_DIR"
-          chmod -R 777 "$REAL_ESTATE_DIR"
-          mkdir -p "$SURVEY_DIR"
-          chmod -R 777 "$SURVEY_DIR"
-          mkdir -p "$ANALYSIS_OUTPUT_DIR"
-          chmod -R 777 "$ANALYSIS_OUTPUT_DIR"
 
           docker run \
           --network none \
@@ -147,6 +181,30 @@ jobs:
           ls -lR report_output_dir
           ls -lR summary_output_dir
 
+      - name: Upload results to Blob store
+        id: upload-results
+        uses: RMI-PACTA/actions/actions/azure/blob-copy@main
+        with:
+          source: ${{ steps.prepare.outputs.test-dir }}
+          destination: ${{ inputs.results-url }}
+          overwrite: false
+
+      - name: Upload report to Blob store
+        id: upload-report
+        uses: RMI-PACTA/actions/actions/azure/blob-copy@main
+        with:
+          source: ${{ steps.prepare.outputs.report-output-dir }}
+          destination: ${{ inputs.reports-url }}
+          overwrite: false
+
+      - name: Upload summary to Blob store
+        id: upload-summary
+        uses: RMI-PACTA/actions/actions/azure/blob-copy@main
+        with:
+          source: ${{ steps.prepare.outputs.summary-output-dir }}
+          destination: ${{ inputs.reports-url }}
+          overwrite: false
+
       # https://github.com/marketplace/actions/azure-cli-action#workflow-to-execute-an-azure-cli-script-of-a-specific-cli-version
       - name: Upload results to blob store
         id: upload
@@ -172,8 +230,26 @@ jobs:
               --source "$SUMMARY_OUTPUT_DIR"/* \
               --destination "$unique_directory" \
               --recursive
-            summary_files="$(ls $SUMMARY_OUTPUT_DIR/executive_summary/*.pdf)"
             echo "summary-url=${unique_directory}/executive_summary/$summary_files" >> "$GITHUB_OUTPUT"
+
+      - name: Export Outputs
+        id: export-outputs
+        env:
+          REPORT_UPLOADED_FILES: ${{ steps.upload-report.outputs.destination-files }}
+          SUMMARY_UPLOADED_FILES: ${{ steps.upload-summary.outputs.destination-files }}
+        run: |
+
+          REPORT_URL="$(
+            echo "$REPORT_UPLOADED_FILES" | jq -rc '. [] | match(".*index.html$") | .string'
+          )"
+          echo "report-url=$REPORT_URL"
+          echo "report-url=$REPORT_URL" >> "$GITHUB_OUTPUT"
+
+          SUMMARY_URL="$(
+            echo "$REPORT_UPLOADED_FILES" | jq -rc '. [] | match(".*template.pdf$") | .string'
+          )"
+          echo "summary-url=$SUMMARY_URL"
+          echo "summary-url=$SUMMARY_URL" >> "$GITHUB_OUTPUT"
 
       - name: Prepare comment artifact
         id: prepare-artifact
@@ -182,8 +258,8 @@ jobs:
           config_name: ${{ inputs.config-name }}
           full_image_name: ${{ inputs.full-image-name }}
           git_sha: ${{ github.event.pull_request.head.sha }}
-          report_url: ${{ steps.upload.outputs.report-url }}
-          summary_url: ${{ steps.upload.outputs.summary-url }}
+          report_url: ${{ steps.export-outputs.outputs.report-url }}
+          summary_url: ${{ steps.export-outputs.outputs.summary-url }}
         run: |
           mkdir -p /tmp/comment-json
           json_filename="$( \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,9 +191,12 @@ jobs:
           "$PARAMETERS"
 
       - name: List outputs
+        env:
+          REPORT_OUTPUT_DIR: ${{ steps.prepare.outputs.report-output-dir }}
+          SUMMARY_OUTPUT_DIR: ${{ steps.prepare.outputs.summary-output-dir }}
         run: |
-          ls -lR report_output_dir
-          ls -lR summary_output_dir
+          ls -lR $REPORT_OUTPUT_DIR
+          ls -lR $SUMMARY_OUTPUT_DIR
 
       - name: Upload results to Blob store
         id: upload-results


### PR DESCRIPTION
Use RMI Blob copy action for file transfer.

Note that this does NOT target `main`, since the CI pipeline on `main` break before the blob copy step, masking the failures in this step. However, a failure in blob upload can be seen in the `update-parameters-array` PR [here](https://github.com/RMI-PACTA/workflow.pacta.webapp/actions/runs/11743514782/job/32716642323?pr=23)