### PR TITLE
Remove custom R CMD Check Matrix

### DIFF
--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -22,15 +22,3 @@ jobs:
     uses: RMI-PACTA/actions/.github/workflows/R.yml@main
     with:
       do-codecov: false
-      r-cmd-check-matrix: |
-        [
-          {"os": "macOS-latest", "r": "release"},
-          {"os": "windows-latest", "r": "4.1"},
-          {"os": "ubuntu-latest", "r": "release"},
-          {"os": "ubuntu-latest", "r": "devel", "http-user-agent": "release"},
-          {"os": "ubuntu-latest", "r": "oldrel-1"},
-          {"os": "ubuntu-latest", "r": "oldrel-2"},
-          {"os": "ubuntu-latest", "r": "oldrel-3"},
-          {"os": "ubuntu-latest", "r": "oldrel-4"}
-        ]
-


### PR DESCRIPTION
the R-CMD-Check matrix included `oldrel-4`, which corresponds to `4.0.3`, which conflicts with a `> 4.1` in our dependencies. 

See https://github.com/RMI-PACTA/actions/pull/117

Depends on #31 for remote dependency.